### PR TITLE
Implement rule CurliesImportChecker

### DIFF
--- a/src/main/resources/default_config.xml
+++ b/src/main/resources/default_config.xml
@@ -304,4 +304,5 @@
       </parameter>
     </parameters>
   </check>
+  <check class="org.scalastyle.scalariform.CurliesImportChecker" level="warning" enabled="false"></check>
 </scalastyle>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -292,6 +292,10 @@ block.import.message = "Avoid block imports"
 block.import.label = "Avoid block imports"
 block.import.description = "Checks that block imports are not used."
 
+curlies.import.message = "Avoid curlies imports"
+curlies.import.label = "Avoid curlies imports"
+curlies.import.description = "Checks that curlies imports are not used."
+
 procedure.declaration.message = "Use : Unit = for procedures"
 procedure.declaration.label = "Use : Unit = for procedures"
 procedure.declaration.description = "Use a : Unit = for procedure declarations"

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -161,6 +161,7 @@
     <checker class="org.scalastyle.scalariform.ImportGroupingChecker" id="import.grouping" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.NotImplementedErrorUsage" id="not.implemented.error.usage" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.BlockImportChecker" id="block.import" defaultLevel="warning"/>
+    <checker class="org.scalastyle.scalariform.CurliesImportChecker" id="curlies.import" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.ProcedureDeclarationChecker" id="procedure.declaration" defaultLevel="warning"/>
     <checker class="org.scalastyle.scalariform.ForBraceChecker" id="for.brace" defaultLevel="warning">
         <parameters>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -452,6 +452,16 @@ Note: If you intend to enable only if expressions in the format below, disable t
  ]]>
  </example-configuration>
  </check>
+ <check id="curlies.import">
+ <justification>
+  Curlies imports (e.g. `import a.{b, c}`) can lead to annoying merge errors in large code bases that are maintained by lot of developers. This rule allows to ensure that only single imports, no renaming and no hiding imports are used in order to minimize merge errors in import declarations.
+ </justification>
+ <example-configuration>
+ <![CDATA[
+    <check level="warning" class="org.scalastyle.scalariform.CurliesImportChecker" enabled="true"/>
+ ]]>
+ </example-configuration>
+ </check>
 
  <check id="procedure.declaration">
  <justification>

--- a/src/main/resources/scalastyle_messages.properties
+++ b/src/main/resources/scalastyle_messages.properties
@@ -288,6 +288,10 @@ block.import.message = Avoid block imports
 block.import.label = Avoid block imports
 block.import.description = Checks that block imports are not used.
 
+curlies.import.message = Avoid curlies imports
+curlies.import.label = Avoid curlies imports
+curlies.import.description = Checks that curlies imports are not used.
+
 procedure.declaration.message = Use : Unit = for procedures
 procedure.declaration.label = Use : Unit = for procedures
 procedure.declaration.description = Use a : Unit = for procedure declarations

--- a/src/main/scala/org/scalastyle/scalariform/CurliesImportChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/CurliesImportChecker.scala
@@ -1,0 +1,46 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import _root_.scalariform.parser.AstNode
+import _root_.scalariform.parser.BlockImportExpr
+import _root_.scalariform.parser.CompilationUnit
+import _root_.scalariform.parser.ImportClause
+import org.scalastyle.PositionError
+import org.scalastyle.ScalariformChecker
+import org.scalastyle.ScalastyleError
+
+class CurliesImportChecker extends ScalariformChecker {
+
+  val errorKey = "curlies.import"
+
+  def verify(ast: CompilationUnit): List[ScalastyleError] =
+    findBlockImports(ast)
+
+  private def findBlockImports(in: AstNode): List[PositionError] = in match {
+
+    // comma separated import
+    case ImportClause(_, firstImport, otherImports, _) if otherImports.nonEmpty =>
+      List(PositionError(firstImport.firstToken.offset))
+    // other block imports
+    case b: BlockImportExpr => List(PositionError(b.firstToken.offset))
+
+    // remaining nodes
+    case a: AstNode => a.immediateChildren flatMap findBlockImports
+  }
+
+}

--- a/src/test/scala/org/scalastyle/scalariform/CurliesImportCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/CurliesImportCheckerTest.scala
@@ -1,0 +1,101 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scalastyle.scalariform
+
+import org.junit.Test
+import org.scalastyle.file.CheckerTest
+import org.scalatestplus.junit.AssertionsForJUnit
+
+// scalastyle:off magic.number
+
+class CurliesImportCheckerTest extends AssertionsForJUnit with CheckerTest {
+
+  val key = "curlies.import"
+  val classUnderTest: Class[CurliesImportChecker] = classOf[CurliesImportChecker]
+
+  @Test
+  def singleImportIsNoBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable.Buffer
+      """
+    assertErrors(Nil, source)
+  }
+
+  @Test
+  def importAllIsNoBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable._
+      """
+    assertErrors(Nil, source)
+  }
+
+  @Test
+  def hideImportIsBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable.{Buffer => _}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+
+  @Test
+  def renameImportIsBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable.{Buffer => MB}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+
+  @Test
+  def commaSeparatedImportIsBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable, mutable.Buffer, mutable.ArrayBuffer
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+
+  @Test
+  def blockImportFound(): Unit = {
+    val source = """
+import scala.collection.mutable.{Buffer, ArrayBuffer}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+
+  @Test
+  def wildcardImportAfterRenameImportsIsBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable.{Buffer => MB, ArrayBuffer => _, _}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+
+  @Test
+  def wildcardImportAfterNormalImportAndRenameImportIsBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable.{Buffer => MB, ArrayBuffer, _}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+
+  @Test
+  def wildcardImportAfterNormalImportIsBlockImport(): Unit = {
+    val source = """
+import scala.collection.mutable.{ArrayBuffer, _}
+      """
+    assertErrors(List(columnError(2, 7)), source)
+  }
+}


### PR DESCRIPTION
As opposed to BlockImportChecker, this rule targets all
imports with curly braces, including renaming or hiding imports.

This is important because scala refactoring tools that allow
to move classes to other packages are often error-prone in
the presence of such imports.