### PR TITLE
Make formatting of xml config more consistent.

### DIFF
--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -1,220 +1,220 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--  scalastyle definition file. This contains the list of checkers and the parameters & types available -->
 <scalastyle-definition>
-    <checker class="org.scalastyle.file.FileTabChecker" id="line.contains.tab" defaultLevel="warning"/>
-    <checker class="org.scalastyle.file.FileLengthChecker" id="file.size.limit" defaultLevel="warning">
-        <parameters>
-            <parameter name="maxFileLength" type="integer" default="1500"/>
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.file.HeaderMatchesChecker" id="header.matches" defaultLevel="warning">
-        <parameters>
-            <parameter name="header" type="string" multiple="true" default=""/>
-            <parameter name="regex" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.SpacesAfterPlusChecker" id="spaces.after.plus" defaultLevel="warning" />
-    <checker class="org.scalastyle.file.WhitespaceEndOfLineChecker" id="whitespace.end.of.line" defaultLevel="warning">
-        <parameters>
-            <parameter name="ignoreWhitespaceLines" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.SpacesBeforePlusChecker" id="spaces.before.plus" defaultLevel="warning" />
-    <checker class="org.scalastyle.file.FileLineLengthChecker" id="line.size.limit" defaultLevel="warning" >
-        <parameters>
-            <parameter name="maxLineLength" type="integer" default="160" />
-            <parameter name="tabSize" type="integer" default="4" />
-            <parameter name="ignoreImports" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.ClassNamesChecker" id="class.name" defaultLevel="warning">
-        <parameters>
-            <parameter name="regex" type="string" default="^[A-Z][A-Za-z]*$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.ObjectNamesChecker" id="object.name" defaultLevel="warning">
-        <parameters>
-            <parameter name="regex" type="string" default="^[A-Z][A-Za-z]*$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.PackageNamesChecker" id="package.name" defaultLevel="warning">
-        <parameters>
-            <parameter name="regex" type="string" default="^[a-z]+$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.PackageObjectNamesChecker" id="package.object.name" defaultLevel="warning">
-        <parameters>
-            <parameter name="regex" type="string" default="^[a-z][A-Za-z]*$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.EqualsHashCodeChecker" id="equals.hash.code"  defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.IllegalImportsChecker" id="illegal.imports" defaultLevel="warning" >
-        <parameters>
-            <parameter name="illegalImports" type="string" default="sun._,java.awt._" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.ParameterNumberChecker" id="parameter.number" defaultLevel="warning" >
-        <parameters>
-            <parameter name="maxParameters" type="integer" default="8" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.MagicNumberChecker" id="magic.number" defaultLevel="warning" >
-        <parameters>
-            <parameter name="ignore" type="string" default="-1,0,1,2" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" id="no.whitespace.before.left.bracket" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" id="no.whitespace.after.left.bracket" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.NoWhitespaceBeforeRightBracketChecker" id="no.whitespace.before.right.bracket" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.ReturnChecker" id="return" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.NullChecker" id="null" defaultLevel="warning">
-        <parameters>
-            <parameter name="allowNullChecks" type="boolean" default="true" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.NoCloneChecker" id="no.clone" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.NoFinalizeChecker" id="no.finalize" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.CovariantEqualsChecker" id="covariant.equals" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.StructuralTypeChecker" id="structural.type" defaultLevel="warning" />
-    <checker class="org.scalastyle.file.RegexChecker" id="regex" defaultLevel="warning" >
-        <parameters>
-            <parameter name="regex" type="string" default="" />
-            <parameter name="line" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.NumberOfTypesChecker" id="number.of.types" defaultLevel="warning" >
-        <parameters>
-            <parameter name="maxTypes" type="integer" default="20" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.CyclomaticComplexityChecker" id="cyclomatic.complexity" defaultLevel="warning" >
-        <parameters>
-            <parameter name="maximum" type="integer" default="10" />
-            <parameter name="countCases" type="boolean" default="true" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.UppercaseLChecker" id="uppercase.l" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" id="simplify.boolean.expression" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.IfBraceChecker" id="if.brace" defaultLevel="warning" >
-        <parameters>
-            <parameter name="singleLineAllowed" type="boolean" default="true" />
-            <parameter name="doubleLineAllowed" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.MethodLengthChecker" id="method.length" defaultLevel="warning" >
-        <parameters>
-            <parameter name="maxLength" type="integer" default="50" />
-            <parameter name="ignoreComments" type="boolean" default="false" />
-            <parameter name="ignoreEmpty" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.MethodNamesChecker" id="method.name" defaultLevel="warning" >
-        <parameters>
-            <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*(_=)?$" />
-            <parameter name="ignoreRegex" type="string" default="^$" />
-            <parameter name="ignoreOverride" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.MethodArgumentNamesChecker" id="method.argument.name" defaultLevel="warning" >
-        <parameters>
-            <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*$" />
-            <parameter name="ignoreRegex" type="string" default="^$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" id="number.of.methods" defaultLevel="warning" >
-        <parameters>
-            <parameter name="maxMethods" type="integer" default="30" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" id="public.methods.have.type" defaultLevel="warning" >
-        <parameters>
-            <parameter name="ignoreOverride" type="boolean" default="false" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.file.NewLineAtEofChecker" id="newline.at.eof" defaultLevel="warning"/>
-    <checker class="org.scalastyle.file.NoNewLineAtEofChecker" id="no.newline.at.eof" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.WhileChecker" id="while" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.VarFieldChecker" id="var.field" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.VarLocalChecker" id="var.local" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.RedundantIfChecker" id="if.redundant" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.TokenChecker" id="token" defaultLevel="warning" >
-        <parameters>
-            <parameter name="regex" type="string" default="^$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.DeprecatedJavaChecker" id="deprecated.java" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.OverrideJavaChecker" id="override.java" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.EmptyClassChecker" id="empty.class" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.ClassTypeParameterChecker" id="class.type.parameter.name" defaultLevel="warning" >
-        <parameters>
-            <parameter name="regex" type="string" default="^[A-Z_]$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.UnderscoreImportChecker" id="underscore.import" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.LowercasePatternMatchChecker" id="lowercase.pattern.match" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" id="multiple.string.literals" defaultLevel="warning" >
-        <parameters>
-            <parameter name="allowed" type="integer" default="1" />
-            <parameter name="ignoreRegex" type="string" default="^&quot;&quot;$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.ImportGroupingChecker" id="import.grouping" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.NotImplementedErrorUsage" id="not.implemented.error.usage" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.BlockImportChecker" id="block.import" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.CurliesImportChecker" id="curlies.import" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.ProcedureDeclarationChecker" id="procedure.declaration" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.ForBraceChecker" id="for.brace" defaultLevel="warning">
-        <parameters>
-            <parameter name="singleLineAllowed" type="boolean" default="false"/>
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.ForLoopChecker" id="for.loop" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" id="space.after.comment.start" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.ScalaDocChecker" id="scaladoc" defaultLevel="warning">
-        <parameters>
-            <parameter name="ignoreRegex" type="string" default="^$"/>
-            <parameter name="ignoreTokenTypes" type="string" default="^$"/>
-            <parameter name="ignoreOverride" type="boolean" default="false"/>
-            <parameter name="indentStyle" type="string" default="anydoc"/>
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" id="disallow.space.after.token" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" id="disallow.space.before.token" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" id="ensure.single.space.after.token" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" id="ensure.single.space.before.token" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.NonASCIICharacterChecker" id="non.ascii.character.disallowed" defaultLevel="warning">
-        <parameters>
-            <parameter name="allowStringLiterals" type="boolean" default="false"/>
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.file.IndentationChecker" id="indentation" defaultLevel="warning">
-        <parameters>
-            <parameter name="tabSize" type="integer" default="2" />
-            <parameter name="methodParamIndentSize" type="integer" default="2" />
-            <parameter name="classParamIndentSize" type="integer" default="4" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.FieldNamesChecker" id="field.name" defaultLevel="warning">
-        <parameters>
-            <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*$" />
-            <parameter name="objectFieldRegex" type="string" default="^[A-Z][A-Za-z0-9]*$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.XmlLiteralChecker" id="xml.literal" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.ImportOrderChecker" id="import.ordering" defaultLevel="warning" />
-    <checker class="org.scalastyle.scalariform.PatternMatchAlignChecker" id="pattern.match.align" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.TodoCommentChecker" id="todo.comment" defaultLevel="warning">
-        <parameters>
-            <parameter name="words" type="string" default="TODO|FIXME" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.EmptyInterpolatedStringChecker" id="empty.interpolated.strings" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.NamedArgumentChecker" id="named.argument" defaultLevel="warning">
-        <parameters>
-            <parameter name="checkString" type="boolean" default="false" />
-            <parameter name="ignoreMethod" type="string" default="^set.+$" />
-        </parameters>
-    </checker>
-    <checker class="org.scalastyle.scalariform.WhileBraceChecker" id="while.brace" defaultLevel="warning"/>
-    <checker class="org.scalastyle.scalariform.CaseBraceChecker" id="disallow.case.brace" defaultLevel="warning"/>
+  <checker class="org.scalastyle.file.FileTabChecker" id="line.contains.tab" defaultLevel="warning"/>
+  <checker class="org.scalastyle.file.FileLengthChecker" id="file.size.limit" defaultLevel="warning">
+    <parameters>
+      <parameter name="maxFileLength" type="integer" default="1500"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.file.HeaderMatchesChecker" id="header.matches" defaultLevel="warning">
+    <parameters>
+      <parameter name="header" type="string" multiple="true" default=""/>
+      <parameter name="regex" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.SpacesAfterPlusChecker" id="spaces.after.plus" defaultLevel="warning"/>
+  <checker class="org.scalastyle.file.WhitespaceEndOfLineChecker" id="whitespace.end.of.line" defaultLevel="warning">
+    <parameters>
+      <parameter name="ignoreWhitespaceLines" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.SpacesBeforePlusChecker" id="spaces.before.plus" defaultLevel="warning"/>
+  <checker class="org.scalastyle.file.FileLineLengthChecker" id="line.size.limit" defaultLevel="warning">
+    <parameters>
+      <parameter name="maxLineLength" type="integer" default="160"/>
+      <parameter name="tabSize" type="integer" default="4"/>
+      <parameter name="ignoreImports" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.ClassNamesChecker" id="class.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[A-Z][A-Za-z]*$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.ObjectNamesChecker" id="object.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[A-Z][A-Za-z]*$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.PackageNamesChecker" id="package.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[a-z]+$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.PackageObjectNamesChecker" id="package.object.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[a-z][A-Za-z]*$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.EqualsHashCodeChecker" id="equals.hash.code" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.IllegalImportsChecker" id="illegal.imports" defaultLevel="warning">
+    <parameters>
+      <parameter name="illegalImports" type="string" default="sun._,java.awt._"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.ParameterNumberChecker" id="parameter.number" defaultLevel="warning">
+    <parameters>
+      <parameter name="maxParameters" type="integer" default="8"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.MagicNumberChecker" id="magic.number" defaultLevel="warning">
+    <parameters>
+      <parameter name="ignore" type="string" default="-1,0,1,2"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" id="no.whitespace.before.left.bracket" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" id="no.whitespace.after.left.bracket" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.NoWhitespaceBeforeRightBracketChecker" id="no.whitespace.before.right.bracket" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.ReturnChecker" id="return" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.NullChecker" id="null" defaultLevel="warning">
+    <parameters>
+      <parameter name="allowNullChecks" type="boolean" default="true"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.NoCloneChecker" id="no.clone" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.NoFinalizeChecker" id="no.finalize" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.CovariantEqualsChecker" id="covariant.equals" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.StructuralTypeChecker" id="structural.type" defaultLevel="warning"/>
+  <checker class="org.scalastyle.file.RegexChecker" id="regex" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default=""/>
+      <parameter name="line" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.NumberOfTypesChecker" id="number.of.types" defaultLevel="warning">
+    <parameters>
+      <parameter name="maxTypes" type="integer" default="20"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.CyclomaticComplexityChecker" id="cyclomatic.complexity" defaultLevel="warning">
+    <parameters>
+      <parameter name="maximum" type="integer" default="10"/>
+      <parameter name="countCases" type="boolean" default="true"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.UppercaseLChecker" id="uppercase.l" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" id="simplify.boolean.expression" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.IfBraceChecker" id="if.brace" defaultLevel="warning">
+    <parameters>
+      <parameter name="singleLineAllowed" type="boolean" default="true"/>
+      <parameter name="doubleLineAllowed" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.MethodLengthChecker" id="method.length" defaultLevel="warning">
+    <parameters>
+      <parameter name="maxLength" type="integer" default="50"/>
+      <parameter name="ignoreComments" type="boolean" default="false"/>
+      <parameter name="ignoreEmpty" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.MethodNamesChecker" id="method.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*(_=)?$"/>
+      <parameter name="ignoreRegex" type="string" default="^$"/>
+      <parameter name="ignoreOverride" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.MethodArgumentNamesChecker" id="method.argument.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*$"/>
+      <parameter name="ignoreRegex" type="string" default="^$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" id="number.of.methods" defaultLevel="warning">
+    <parameters>
+      <parameter name="maxMethods" type="integer" default="30"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" id="public.methods.have.type" defaultLevel="warning">
+    <parameters>
+      <parameter name="ignoreOverride" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.file.NewLineAtEofChecker" id="newline.at.eof" defaultLevel="warning"/>
+  <checker class="org.scalastyle.file.NoNewLineAtEofChecker" id="no.newline.at.eof" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.WhileChecker" id="while" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.VarFieldChecker" id="var.field" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.VarLocalChecker" id="var.local" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.RedundantIfChecker" id="if.redundant" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.TokenChecker" id="token" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.DeprecatedJavaChecker" id="deprecated.java" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.OverrideJavaChecker" id="override.java" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.EmptyClassChecker" id="empty.class" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.ClassTypeParameterChecker" id="class.type.parameter.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[A-Z_]$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.UnderscoreImportChecker" id="underscore.import" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.LowercasePatternMatchChecker" id="lowercase.pattern.match" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" id="multiple.string.literals" defaultLevel="warning">
+    <parameters>
+      <parameter name="allowed" type="integer" default="1"/>
+      <parameter name="ignoreRegex" type="string" default="^&quot;&quot;$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.ImportGroupingChecker" id="import.grouping" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.NotImplementedErrorUsage" id="not.implemented.error.usage" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.BlockImportChecker" id="block.import" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.CurliesImportChecker" id="curlies.import" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.ProcedureDeclarationChecker" id="procedure.declaration" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.ForBraceChecker" id="for.brace" defaultLevel="warning">
+    <parameters>
+      <parameter name="singleLineAllowed" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.ForLoopChecker" id="for.loop" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" id="space.after.comment.start" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.ScalaDocChecker" id="scaladoc" defaultLevel="warning">
+    <parameters>
+      <parameter name="ignoreRegex" type="string" default="^$"/>
+      <parameter name="ignoreTokenTypes" type="string" default="^$"/>
+      <parameter name="ignoreOverride" type="boolean" default="false"/>
+      <parameter name="indentStyle" type="string" default="anydoc"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" id="disallow.space.after.token" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" id="disallow.space.before.token" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" id="ensure.single.space.after.token" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" id="ensure.single.space.before.token" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.NonASCIICharacterChecker" id="non.ascii.character.disallowed" defaultLevel="warning">
+    <parameters>
+      <parameter name="allowStringLiterals" type="boolean" default="false"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.file.IndentationChecker" id="indentation" defaultLevel="warning">
+    <parameters>
+      <parameter name="tabSize" type="integer" default="2"/>
+      <parameter name="methodParamIndentSize" type="integer" default="2"/>
+      <parameter name="classParamIndentSize" type="integer" default="4"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.FieldNamesChecker" id="field.name" defaultLevel="warning">
+    <parameters>
+      <parameter name="regex" type="string" default="^[a-z][A-Za-z0-9]*$"/>
+      <parameter name="objectFieldRegex" type="string" default="^[A-Z][A-Za-z0-9]*$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.XmlLiteralChecker" id="xml.literal" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.ImportOrderChecker" id="import.ordering" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.PatternMatchAlignChecker" id="pattern.match.align" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.TodoCommentChecker" id="todo.comment" defaultLevel="warning">
+    <parameters>
+      <parameter name="words" type="string" default="TODO|FIXME"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.EmptyInterpolatedStringChecker" id="empty.interpolated.strings" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.NamedArgumentChecker" id="named.argument" defaultLevel="warning">
+    <parameters>
+      <parameter name="checkString" type="boolean" default="false"/>
+      <parameter name="ignoreMethod" type="string" default="^set.+$"/>
+    </parameters>
+  </checker>
+  <checker class="org.scalastyle.scalariform.WhileBraceChecker" id="while.brace" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.CaseBraceChecker" id="disallow.case.brace" defaultLevel="warning"/>
 </scalastyle-definition>

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--  scalastyle definition file. This contains the list of checkers and the parameters & types available -->
 <scalastyle-definition>
   <checker class="org.scalastyle.file.FileTabChecker" id="line.contains.tab" defaultLevel="warning"/>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -11,7 +11,7 @@
       ]]>
     </example-configuration>
   </check>
-  <check> id="line.size.limit">
+  <check id="line.size.limit">
     <justification>Lines that are too long can be hard to read and horizontal scrolling is annoying.</justification>
     <example-configuration>
       <![CDATA[
@@ -25,7 +25,7 @@
       ]]>
     </example-configuration>
   </check>
-  <check> id="magic.number">
+  <check id="magic.number">
     <justification>Replacing a magic number with a named constant can make code easier to read and understand, and can avoid some subtle bugs.</justification>
     <extra-description>A simple assignment to a val is not considered to be a magic number, for example: `val foo = 4` is not a magic number, but `var foo = 4` is considered to be a magic number.</extra-description>
     <example-configuration>
@@ -38,7 +38,7 @@
       ]]>
     </example-configuration>
   </check>
-  <check> id="regex">
+  <check id="regex">
     <justification>Some checks can be carried out with a regular expression.</justification>
     <example-configuration>
       <![CDATA[
@@ -52,7 +52,7 @@
       ]]>
     </example-configuration>
   </check>
-  <check> id="number.of.types">
+  <check id="number.of.types">
     <justification>If there are too many classes/objects defined in a single file, this can cause the code to be difficult to understand.</justification>
     <example-configuration>
       <![CDATA[
@@ -338,7 +338,7 @@ val lc = "lc"
       ]]>
     </example-configuration>
   </check>
-  <check> id="not.implemented.error.usage">
+  <check id="not.implemented.error.usage">
     <justification>The `???` operator denotes that an implementation is missing. This rule helps to avoid potential runtime errors because of not implemented code.</justification>
     <example-configuration>
       <![CDATA[
@@ -346,7 +346,7 @@ val lc = "lc"
       ]]>
     </example-configuration>
   </check>
-  <check> id="block.import">
+  <check id="block.import">
     <justification>Block imports, e.g. `import a.{b, c}` can lead to annoying merge errors in large code bases that are maintained by lot of developers. This rule allows to ensure that only single imports are used in order to minimize merge errors in import declarations.</justification>
     <example-configuration>
       <![CDATA[
@@ -354,7 +354,7 @@ val lc = "lc"
       ]]>
     </example-configuration>
   </check>
-  <check> id="curlies.import">
+  <check id="curlies.import">
     <justification>Curlies imports, e.g. `import a.{b, c}`, can lead to annoying merge errors in large code bases that are maintained by lot of developers. This rule allows to ensure that only single imports, no renaming and no hiding imports are used in order to minimize merge errors in import declarations.</justification>
     <example-configuration>
       <![CDATA[
@@ -420,7 +420,7 @@ for (i &lt;- List(1,2,3)) yield i
       ]]>
     </example-configuration>
   </check>
-  <check> id="for.loop">
+  <check id="for.loop">
     <justification>
 For-comprehensions which lack a `yield` clause is actually a loop rather than a functional comprehension and it is usually more readable to string the generators together between parentheses rather than using the syntactically-confusing `} {` construct:
 
@@ -447,7 +447,7 @@ for {
       ]]>
     </example-configuration>
   </check>
-  <check> id="space.after.comment.start">
+  <check id="space.after.comment.start">
     <justification>
 To bring consistency with how comments should be formatted, leave a space right after the beginning of the comment.
 
@@ -475,7 +475,7 @@ object Foobar {
       ]]>
     </example-configuration>
   </check>
-  <check> id="non.ascii.character.disallowed">
+  <check id="non.ascii.character.disallowed">
     <justification>
 Scala allows unicode characters as operators and some editors misbehave when they see non-ascii character. In a project collaborated by a community of developers. This check can be helpful in such situations. 
 
@@ -852,7 +852,7 @@ To fix it, replace the (unicode operator) `⇒` with `=>`.
       ]]>
     </example-configuration>
   </check>
-  <check> id="pattern.match.align">
+  <check id="pattern.match.align">
     <justification>Correct formatting can help readability.</justification>
     <example-configuration>
       <![CDATA[
@@ -860,7 +860,7 @@ To fix it, replace the (unicode operator) `⇒` with `=>`.
       ]]>
     </example-configuration>
   </check>
-  <check> id="empty.interpolated.strings">
+  <check id="empty.interpolated.strings">
     <justification>Empty interpolated strings are harder to read and not necessary.</justification>
     <example-configuration>
       <![CDATA[

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -1,1096 +1,900 @@
 <scalastyle-documentation>
- <check id="file.size.limit">
- <justification>
- Files which are too long can be hard to read and understand.
- </justification>
- <example-configuration>
- <![CDATA[
- <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxFileLength">800</parameter>
-  </parameters>
- </check>
- ]]>
- </example-configuration>
- </check>
+  <check id="file.size.limit">
+    <justification>Files which are too long can be hard to read and understand.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+          <parameters>
+            <parameter name="maxFileLength">800</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="line.size.limit">
+    <justification>Lines that are too long can be hard to read and horizontal scrolling is annoying.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+          <parameters>
+            <parameter name="maxLineLength">100</parameter>
+            <parameter name="tabSize">2</parameter>
+            <parameter name="ignoreImports">true</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="magic.number">
+    <justification>Replacing a magic number with a named constant can make code easier to read and understand, and can avoid some subtle bugs.</justification>
+    <extra-description>A simple assignment to a val is not considered to be a magic number, for example: `val foo = 4` is not a magic number, but `var foo = 4` is considered to be a magic number.</extra-description>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+          <parameters>
+            <parameter name="ignore">-1,0,1,2,3</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="regex">
+    <justification>Some checks can be carried out with a regular expression.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">(?m)^\s*$(\r|)\n^\s*$(\r|)\n</parameter>
+            <parameter name="line">false</parameter>
+          </parameters>
+          <customMessage>No double blank lines</customMessage>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="number.of.types">
+    <justification>If there are too many classes/objects defined in a single file, this can cause the code to be difficult to understand.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+          <parameters>
+            <parameter name="maxTypes">20</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="cyclomatic.complexity">
+    <justification>If the code is too complex, then this can make code hard to read.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+          <parameters>
+            <parameter name="maximum">10</parameter>
+            <parameter name="countCases">true</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="uppercase.l">
+    <justification>A lowercase L (l) can look similar to a number 1 with some fonts.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="if.brace">
+    <justification>Some people find if clauses with braces easier to read.</justification>
+    <extra-description>
+The `singleLineAllowed` property allows if constructions of the type:
 
- <check id="line.size.limit">
- <justification>
- Lines that are too long can be hard to read and horizontal scrolling is annoying.
- </justification>
- <example-configuration>
- <![CDATA[
- <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLineLength">100</parameter>
-   <parameter name="tabSize">2</parameter>
-   <parameter name="ignoreImports">true</parameter>
-  </parameters>
- </check>
- ]]>
- </example-configuration>
- </check>
+```scala
+if (bool_expression) expression1 else expression2
+```
 
+The `doubleLineAllowed` property allows if constructions of the type:
 
- <check id="magic.number">
- <justification>
- Replacing a magic number with a named constant can make code easier to read and understand, and can avoid some subtle bugs.
- </justification>
- <extra-description>
- A simple assignment to a val is not considered to be a magic number, for example:
-
-    val foo = 4
-
-is not a magic number, but
-
-    var foo = 4
-
-is considered to be a magic number.
- </extra-description>
- <example-configuration>
- <![CDATA[
- <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="ignore">-1,0,1,2,3</parameter>
-  </parameters>
- </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="regex">
- <justification>
- Some checks can be carried out with a regular expression.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">(?m)^\s*$(\r|)\n^\s*$(\r|)\n</parameter>
-        <parameter name="line">false</parameter>
-      </parameters>
-      <customMessage>No double blank lines</customMessage>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="number.of.types">
- <justification>
- If there are too many classes/objects defined in a single file, this can cause the code to be difficult to understand.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
-      <parameters>
-        <parameter name="maxTypes">20</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="cyclomatic.complexity">
- <justification>
- If the code is too complex, then this can make code hard to read.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
-      <parameters>
-        <parameter name="maximum">10</parameter>
-        <parameter name="countCases">true</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="uppercase.l">
- <justification>
- A lowercase L (l) can look similar to a number 1 with some fonts.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
-
- <check id="if.brace">
- <justification>
- Some people find if clauses with braces easier to read.
- </justification>
- <extra-description>
- The singleLineAllowed property allows if constructions of the type:
-
-    if (bool_expression) expression1 else expression2
-
-The doubleLineAllowed property allows if constructions of the type:
-
-    if (bool_expression) expression1
-    else expression2
+```scala
+if (bool_expression) expression1 else expression2
+```
 
 Note: If you intend to enable only if expressions in the format below, disable the IfBraceChecker altogether.
 
-    if (bool_expression)
-      expression1
-    else
-      expression2
- </extra-description>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
-      <parameters>
-        <parameter name="singleLineAllowed">true</parameter>
-        <parameter name="doubleLineAllowed">false</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
+```scala
+if (bool_expression) expression1 else expression2
+```
+    </extra-description>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+          <parameters>
+            <parameter name="singleLineAllowed">true</parameter>
+            <parameter name="doubleLineAllowed">false</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="method.length">
+    <justification>Long methods can be hard to read and understand.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+          <parameters>
+            <parameter name="maxLength">50</parameter>
+            <parameter name="ignoreComments">false</parameter>
+            <parameter name="ignoreEmpty">false</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="method.name">
+    <justification>The Scala style guide recommends that method names conform to certain standards. If the methods are overriding another method, and the overridden method cannot be changed, then use the `ignoreOverride` parameter.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[A-Za-z]*$</parameter>
+            <parameter name="ignoreRegex">^.*$</parameter>
+            <parameter name="ignoreOverride">false</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="method.argument.name">
+    <justification>The Scala style guide recommends that method argument names conform to certain standards.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.MethodArgumentNamesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[a-z][A-Za-z0-9]*$</parameter>
+            <parameter name="ignoreRegex">^$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="number.of.methods">
+    <justification>If a type declares too many methods, this can be an indication of bad design.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+          <parameters>
+            <parameter name="maxMethods">30</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="public.methods.have.type">
+    <justification>A public method declared on a type is effectively an API declaration. Explicitly declaring a return type means that other code which depends on that type won't break unexpectedly.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+          <parameters>
+            <parameter name="ignoreOverride">false</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="newline.at.eof">
+    <justification>Some version control systems don't cope well with files which don't end with a newline character.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="no.newline.at.eof">
+    <justification>Because Mirco Dotta wanted it.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="while">
+    <justification>`while` loops are deprecated if you're using a strict functional style.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="var.field">
+    <justification>`var` (mutable fields) are deprecated if you're using a strict functional style.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="var.local">
+    <justification>`var` (mutable local variables) are deprecated if you're using a strict functional style</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="if.redundant">
+    <justification>If expressions with boolean constants in both branches can be eliminated without affecting readability. Prefer simply `cond` to `if (cond) true else false` and `!cond` to `if (cond) false else true`.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="token">
+    <justification>Some checks can be carried by just the presence of a particular token.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[ai]sInstanceOf$</parameter>
+          </parameters>
+          <customMessage>Avoid casting.</customMessage>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="deprecated.java">
+    <justification>You should be using the Scala `@deprecated` instead.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="override.java">
+    <justification>You should be using the Scala override keyword instead.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.OverrideJavaChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="empty.class">
+    <justification>If a `class` / `trait` has no members, then braces are unnecessary, and can be removed.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="class.type.parameter.name">
+    <justification>Scala generic type names are generally single upper case letters. This check checks for classes and traits. Note that this check only checks the innermost type parameter, to allow for `List[T]`.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[A-Z_]$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="underscore.import">
+    <justification>Importing all classes from a package or static members from a class leads to tight coupling between packages or classes and might lead to problems when a new version of a library introduces name clashes.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true">
+          <parameters>
+            <parameter name="ignoreRegex">collection\.JavaConverters\._|scala\.concurrent\.duration\._</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="lowercase.pattern.match">
+    <justification>
+A lower case pattern match clause with no other tokens is the same as `_`; this is not true for patterns which start with an upper case letter. This can cause confusion, and may not be what was intended:
 
- <check id="method.length">
- <justification>
- Long methods can be hard to read and understand.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-      <parameters>
-        <parameter name="maxLength">50</parameter>
-        <parameter name="ignoreComments">false</parameter>
-        <parameter name="ignoreEmpty">false</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
+```scala
+val foo = "foo"
+val Bar = "bar"
+"bar" match { case Bar => "we got bar" } // result = "we got bar"
+"bar" match { case foo => "we got foo" } // result = "we got foo"
+"bar" match { case `foo` => "we got foo" } // result = MatchError
+```
 
- <check id="method.name">
- <justification>
- The Scala style guide recommends that method names conform to certain standards. If the methods are overriding another method, and the overridden method
- cannot be changed, then use the ignoreOverride parameter.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[A-Za-z]*$</parameter>
-        <parameter name="ignoreRegex">^.*$</parameter>
-        <parameter name="ignoreOverride">false</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
+This checker raises a warning with the second match. To fix it, use an identifier which starts with an upper case letter (best), use `case _` or, if you wish to refer to the value, add a type `: Any`, e.g.:
 
- <check id="method.argument.name">
-  <justification>
-   The Scala style guide recommends that method argument names conform to certain standards.
-  </justification>
-  <example-configuration>
-   <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.MethodArgumentNamesChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[a-z][A-Za-z0-9]*$</parameter>
-        <parameter name="ignoreRegex">^$</parameter>
-      </parameters>
-    </check>
- ]]>
-  </example-configuration>
- </check>
+```scala
+val lc = "lc"
+"something" match { case lc: Any => "lc" } // result = "lc"
+"something" match { case _ => "lc" } // result = "lc"
+```
+    </justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="multiple.string.literals">
+    <justification>Code duplication makes maintenance more difficult, so it can be better to replace the multiple occurrences with a constant.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+          <parameters>
+            <parameter name="allowed">1</parameter>
+            <parameter name="ignoreRegex">^\"\"$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="import.grouping">
+    <justification>If imports are spread throughout the file, knowing what is in scope at any one place can be difficult to work out.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="not.implemented.error.usage">
+    <justification>The `???` operator denotes that an implementation is missing. This rule helps to avoid potential runtime errors because of not implemented code.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="block.import">
+    <justification>Block imports, e.g. `import a.{b, c}` can lead to annoying merge errors in large code bases that are maintained by lot of developers. This rule allows to ensure that only single imports are used in order to minimize merge errors in import declarations.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.BlockImportChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="curlies.import">
+    <justification>Curlies imports, e.g. `import a.{b, c}`, can lead to annoying merge errors in large code bases that are maintained by lot of developers. This rule allows to ensure that only single imports, no renaming and no hiding imports are used in order to minimize merge errors in import declarations.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.CurliesImportChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="procedure.declaration">
+    <justification>
+A procedure style declaration can cause confusion - the developer may have simply forgotten to add a `=`, and now their method returns `Unit` rather than the inferred type:
 
- <check id="number.of.methods">
- <justification>
- If a type declares too many methods, this can be an indication of bad design.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
-      <parameters>
-        <parameter name="maxMethods">30</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
+```scala
+def foo() { println("hello"); 5 }
+```
+This checker raises a warning with the first line. To fix it, use an explicit return type, or add a `=` before the body.
 
- <check id="public.methods.have.type">
- <justification>
- A public method declared on a type is effectively an API declaration. Explicitly declaring a return type means that other code which depends on that type won't break unexpectedly.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
-      <parameters>
-        <parameter name="ignoreOverride">false</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
+```scala
+def foo() = { println("hello"); 5 }
+```
+    </justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="for.brace">
+    <justification>
+Usage of braces (rather than parentheses) within a `for` comprehension mean that you don't have to specify a semi-colon at the end of every line:
 
- <check id="newline.at.eof">
- <justification>
- Some version control systems don't cope well with files which don't end with a newline character.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
+```scala
+for { // braces
+  t &lt;- List(1,2,3)
+  if (t % 2 == 0)
+} yield t
+```
 
- <check id="no.newline.at.eof">
- <justification>
- Because Mirco Dotta wanted it.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
+is preferred to
 
- <check id="while">
- <justification>
- while loops are deprecated if you're using a strict functional style
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
+```scala
+for ( // parentheses
+  t &lt;- List(1,2,3);
+  if (t % 2 == 0)
+) yield t
+```
 
- <check id="var.field">
- <justification>
- var (mutable fields) are deprecated if you're using a strict functional style
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
+To fix it, replace the `()` with `{}`. And then remove the `;` at the end of the lines.
+    </justification>
+    <extra-description>
+The `singleLineAllowed` property allows for constructions of the type:
 
- <check id="var.local">
- <justification>
- vars (mutable local variables) loops are deprecated if you're using a strict functional style
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
+```scala
+for (i &lt;- List(1,2,3)) yield i
+```
+    </extra-description>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true">
+          <parameters>
+            <parameter name="singleLineAllowed">true</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="for.loop">
+    <justification>
+For-comprehensions which lack a `yield` clause is actually a loop rather than a functional comprehension and it is usually more readable to string the generators together between parentheses rather than using the syntactically-confusing `} {` construct:
 
- <check id="if.redundant">
- <justification>
- If expressions with boolean constants in both branches can be eliminated without affecting readability. Prefer simply `cond` to `if (cond) true else false` and `!cond` to `if (cond) false else true`.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
+```scala
+for (x &lt;- board.rows; y &lt;- board.files) {
+  printf("(%d, %d)", x, y)
+}
+```
 
- <check id="token">
- <justification>
- Some checks can be carried by just the presence of a particular token.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[ai]sInstanceOf$</parameter>
-      </parameters>
-      <customMessage>Avoid casting.</customMessage>
-    </check>
- ]]>
- </example-configuration>
- </check>
+is preferred to
 
- <check id="deprecated.java">
- <justification>
- You should be using the Scala @deprecated instead.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="override.java">
-  <justification>
-   You should be using the Scala override keyword instead.
-  </justification>
-  <example-configuration>
-   <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.OverrideJavaChecker" enabled="true" />
- ]]>
-  </example-configuration>
- </check>
-
- <check id="empty.class">
- <justification>
- If a class / trait has no members, then braces are unnecessary, and can be removed.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="class.type.parameter.name">
- <justification>
- Scala generic type names are generally single upper case letters. This check checks for classes and traits.
-
- Note that this check only checks the innermost type parameter, to allow for List\[T\].
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[A-Z_]$</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="underscore.import">
- <justification>
-  Importing all classes from a package or static members from a class leads to tight coupling between packages or classes and might lead to problems when a new version of a library introduces name clashes.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true" >
-      <parameters>
-        <parameter name="ignoreRegex">collection\.JavaConverters\._|scala\.concurrent\.duration\._</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="lowercase.pattern.match">
- <justification>
-  A lower case pattern match clause with no other tokens is the same as \_; this is not true for patterns which start with an upper
-  case letter. This can cause confusion, and may not be what was intended:
-
-    val foo = "foo"
-    val Bar = "bar"
-    "bar" match { case Bar => "we got bar" }   // result = "we got bar"
-    "bar" match { case foo => "we got foo" }   // result = "we got foo"
-    "bar" match { case `foo` => "we got foo" } // result = MatchError
-
-  This checker raises a warning with the second match. To fix it, use an identifier which starts with an upper case letter (best), use case \_ or,
-  if you wish to refer to the value, add a type `: Any`
-
-    val lc = "lc"
-    "something" match { case lc: Any => "lc" } // result = "lc"
-    "something" match { case _ => "lc" } // result = "lc"
-
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="multiple.string.literals">
- <justification>
-  Code duplication makes maintenance more difficult, so it can be better to replace the multiple occurrences with a constant.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
-      <parameters>
-        <parameter name="allowed">1</parameter>
-        <parameter name="ignoreRegex">^\"\"$</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
-
- <check id="import.grouping">
- <justification>
-  If imports are spread throughout the file, knowing what is in scope at any one place can be difficult to work out.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="not.implemented.error.usage">
- <justification>
-  The ??? operator denotes that an implementation is missing. This rule helps to avoid potential runtime errors because of not implemented code.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true" />
- ]]>
- </example-configuration>
- </check>
- <check id="block.import">
- <justification>
-  Block imports (e.g. `import a.{b, c}`) can lead to annoying merge errors in large code bases that are maintained by lot of developers. This rule allows to ensure that only single imports are used in order to minimize merge errors in import declarations.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.BlockImportChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
- <check id="curlies.import">
- <justification>
-  Curlies imports (e.g. `import a.{b, c}`) can lead to annoying merge errors in large code bases that are maintained by lot of developers. This rule allows to ensure that only single imports, no renaming and no hiding imports are used in order to minimize merge errors in import declarations.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.CurliesImportChecker" enabled="true"/>
- ]]>
- </example-configuration>
- </check>
-
- <check id="procedure.declaration">
- <justification>
-  A procedure style declaration can cause confusion - the developer may have simply forgotten to add a '=', and now their method returns Unit rather than the inferred type:
-
-    def foo() { println("hello"); 5 }
-    def foo() = { println("hello"); 5 }
-
-  This checker raises a warning with the first line. To fix it, use an explicit return type, or add a '=' before the body.
-
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="for.brace">
- <justification>
-  Usage of braces (rather than parentheses) within a for comprehension mean that you don't have to specify a semi-colon at the end of every line:
-
-    for {      // braces
-      t &lt;- List(1,2,3)
-      if (i % 2 == 0)
-    } yield t
-
-  is preferred to
-
-    for (      // parentheses
-      t &lt;- List(1,2,3);
-      if (i % 2 == 0)
-    ) yield t
-
-  To fix it, replace the () with {}. And then remove the ; at the end of the lines.
- </justification>
- <extra-description>
- The singleLineAllowed property allows for constructions of the type:
-
-    for (i &lt;- List(1,2,3)) yield i
- </extra-description>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true">
-      <parameters>
-        <parameter name="singleLineAllowed">true</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-<check id="for.loop">
-<justification>
-   For-comprehensions which lack a yield clause is actually a loop rather than a functional comprehension and it is usually
-   more readable to string the generators together between parentheses rather than using the syntactically-confusing } { construct:
-
-   for (x &lt;- board.rows; y &lt;- board.files) {
-     printf("(%d, %d)", x, y)
-   }
-
-   is preferred to
-
-   for {
-     x &lt;- board.rows
-     y &lt;- board.files
-   } {
-     printf("(%d, %d)", x, y)
-   }
-</justification>
-<example-configuration>
- <![CDATA[
-  <check level="warning" class="org.scalastyle.scalariform.ForLoopChecker" enabled="true" />
-]]>
-</example-configuration>
-</check>
-<check id="space.after.comment.start">
-<justification>
+```scala
+for {
+  x &lt;- board.rows
+  y &lt;- board.files
+} {
+  printf("(%d, %d)", x, y)
+}
+```
+    </justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ForLoopChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="space.after.comment.start">
+    <justification>
 To bring consistency with how comments should be formatted, leave a space right after the beginning of the comment.
 
-    package foobar
+```scala
+package foobar
 
-    object Foobar {
-    /**WRONG
+object Foobar {
+  /**WRONG
     *
     */
-    /** Correct*/
-    val d = 2 /*Wrong*/ //Wrong
-    /**
-    *Correct
+  /** Correct
+    *
     */
-    val e = 3/** Correct*/ // Correct
-    }
-</justification>
-<example-configuration>
-<![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true" />
-]]>
-</example-configuration>
+  val d = 2 /*Wrong*/ //Wrong
+  /**
+    * Correct
+    */
+  val e = 3 /** Correct*/ // Correct
+}
+```
+    </justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="non.ascii.character.disallowed">
+    <justification>
+Scala allows unicode characters as operators and some editors misbehave when they see non-ascii character. In a project collaborated by a community of developers. This check can be helpful in such situations. 
 
-</check>
-<check id="non.ascii.character.disallowed">
-  <justification>
-    Scala allows unicode characters as operators and some editors misbehave when they see non-ascii character.
-    In a project collaborated by a community of developers. This check can be helpful in such situations.
+```scala
+"value" match {
+  case "value" => println("matched")
+  ...
+}
+```
 
+is preferred to
 
-    "value".match {
-    case "value" => println("matched")
-    ...
-    }
+```scala
+"value" match {
+  case "value" ⇒ println("matched")
+  ...
+}
+```
 
-    is preferred to
-
-    "value".match {
-    case "value" ⇒ println("matched")
-    ...
-    }
-
-    To fix it, replace the (unicode operator)⇒ with =>.
-  </justification>
-  <example-configuration>
+To fix it, replace the (unicode operator) `⇒` with `=>`.
+    </justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="true">
+          <parameters>
+            <parameter name="allowStringLiterals">true</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="header.matches">
+    <justification>A lot of projects require a header with a copyright notice, or they require a license in each file. This does a simple text comparison between the header and the first lines of the file. You can have multiple lines, but make sure you surround the text with a `CDATA` section. You can also specify a regular expression, as long as you set the regex parameter to `true`.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">false</parameter>
+            <parameter name="header"><![CDATA[// Copyright \(C\) 2011-2012 the original author or authors.]]]]><![CDATA[></parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">true</parameter>
+            <parameter name="header"><![CDATA[// Copyright \(C\) (?:\d{4}-)?\d{4} the original author or authors.]]]]><![CDATA[></parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="field.name">
+    <justification>A consistent naming convention for field names can make code easier to read and understand.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[a-z][A-Za-z0-9]*$</parameter>
+            <parameter name="objectFieldRegex">^[A-Z][A-Za-z0-9]*$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="xml.literal">
+    <justification>Some projects prefer not to have XML literals. They could use a templating engine instead.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.XmlLiteralChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="todo.comment">
+    <justification>Some projects may consider `TODO` or `FIXME` comments in a code bad style. They would rather you fix the problem.</justification>
+    <example-configuration>
     <![CDATA[
-      <check level="warning" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="true">
-        <parameters>
-         <parameter name="allowStringLiterals">true</parameter>
-        </parameters>
-      </check>
-    ]]>
-  </example-configuration>
-</check>
-
-<check id="header.matches">
- <justification>
-  A lot of projects require a header with a copyright notice, or they require a license in each file. This does a simple text comparison between the header and the first lines of the file.
-  You can have multiple lines, but make sure you surround the text with a CDATA section. You can also specify a regular expression, as long as you set the regex parameter to true.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex">false</parameter>
-   <parameter name="header"><![CDATA[// Copyright \(C\) 2011-2012 the original author or authors.]]]]><![CDATA[></parameter>
-  </parameters>
- </check>
- ]]>
- </example-configuration>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex">true</parameter>
-   <parameter name="header"><![CDATA[// Copyright \(C\) (?:\d{4}-)?\d{4} the original author or authors.]]]]><![CDATA[></parameter>
-  </parameters>
- </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="field.name">
- <justification>A consistent naming convention for field names can make code easier to read and understand</justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex">^[a-z][A-Za-z0-9]*$</parameter>
-   <parameter name="objectFieldRegex">^[A-Z][A-Za-z0-9]*$</parameter>
-  </parameters>
- </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="xml.literal">
- <justification>Some projects prefer not to have XML literals. They could use a templating engine instead.</justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.XmlLiteralChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="todo.comment">
- <justification>Some projects may consider TODO or FIXME comments in a code bad style. They would rather you fix the problem.</justification>
- <example-configuration>
- <![CDATA[
-   <check level="warning" class="org.scalastyle.scalariform.TodoCommentChecker" enabled="true">
-     <parameters>
-       <parameter name="words" type="string" default="TODO|FIXME" />
-     </parameters>
-   </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="line.contains.tab">
- <justification>Some say that tabs are evil.</justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="class.name">
- <justification>
- The Scala style guide recommends that class names conform to certain standards.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[A-Z][A-Za-z]*$</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="object.name">
- <justification>
- The Scala style guide recommends that object names conform to certain standards.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[A-Z][A-Za-z]*$</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="package.name">
- <justification>
- The Scala style guide recommends that package names conform to certain standards.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.PackageNamesChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[a-z]+$</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="package.object.name">
- <justification>
- The Scala style guide recommends that package object names conform to certain standards.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
-      <parameters>
-        <parameter name="regex">^[a-z][A-Za-z]*$</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="null">
- <justification>
- Scala discourages use of nulls, preferring Option.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true">
-      <parameters>
-        <parameter name="allowNullChecks">true</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="return">
- <justification>
- Use of return is not usually necessary in Scala. In fact, use of return can discourage a functional style of programming.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="equals.hash.code">
- <justification>
- Defining either equals or hashCode in a class without defining the is a known source of bugs. Usually, when you define one, you should also define the other.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="structural.type">
- <justification>
- Structural types in Scala can use reflection - this can have unexpected performance consequences.
-Warning: This check can also wrongly pick up type lamdbas and other such constructs. This checker should be used with care. You always have the alternative of the scalac checking for structural types.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="no.clone">
- <justification>
-  The clone method is difficult to get right. You can use the copy constructor of case classes rather than implementing clone.
-  For more information on clone(), see Effective Java by Joshua Bloch pages.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="no.finalize">
- <justification>
- finalize() is called when the object is garbage collected, and garbage collection is not guaranteed to happen.
- It is therefore unwise to rely on code in finalize() method.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="indentation">
- <justification>
- Code that is not indented consistently can be hard to read.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.IndentationChecker" enabled="true">
-      <parameters>
-        <parameter name="tabSize">2</parameter>
-        <parameter name="methodParamIndentSize">2</parameter>
-        <parameter name="classParamIndentSize">4</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="whitespace.end.of.line">
- <justification>
- Whitespace at the end of a line can cause problems when diffing between files or between versions.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true">
-     <parameters>
-      <parameter name="ignoreWhitespaceLines" type="boolean" default="false" />
-     </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="illegal.imports">
- <justification>
- Use of some classes can be discouraged for a project. For instance, use of sun._ is generally discouraged because
- they are internal to the JDK and can be changed.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="parameter.number">
- <justification>
- A method which has more than a certain number of parameters can be hard to understand.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-      <parameters>
-        <parameter name="maxParameters">8</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="simplify.boolean.expression">
- <justification>
- A boolean expression which can be simplified can make code easier to read.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="spaces.before.plus">
- <justification>
- An expression with spaces around + can be easier to read
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="spaces.after.plus">
- <justification>
- An expression with spaces around + can be easier to read
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="no.whitespace.before.left.bracket">
- <justification>
- If there is whitespace before a left bracket, this can be confusing to the reader
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="no.whitespace.after.left.bracket">
- <justification>
- If there is whitespace after a left bracket, this can be confusing to the reader
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="no.whitespace.before.right.bracket">
-  <justification>
-   If there is whitespace before a right bracket, this can be confusing to the reader
-  </justification>
-  <example-configuration>
-   <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeRightBracketChecker" enabled="true" />
- ]]>
-  </example-configuration>
- </check>
-
- <check id="covariant.equals">
- <justification>
- Mistakenly defining a covariant equals() method without overriding method equals(java.lang.Object) can produce unexpected runtime behaviour.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true" />
- ]]>
- </example-configuration>
- </check>
-
- <check id="scaladoc">
- <justification>
- Scaladoc is generally considered a good thing. Within reason.
- </justification>
- <extra-description>
- Ignore tokens is a comma separated string that may include the following : PatDefOrDcl (variables), TmplDef (classes, traits), TypeDefOrDcl (type definitions), FunDefOrDcl (functions)
- Supported indentation styles are "scaladoc" (for ScalaDoc-style comments, with two spaces before the asterisk), "javadoc" (for JavaDoc-style comments, with a single space before the asterisk) or "anydoc" to support any style (any number of spaces before the asterisk). For backwards compatibility, if left empty, "anydoc" will be assumed.
- </extra-description>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true">
-      <parameters>
-        <parameter name="ignoreRegex">(.*Spec$)|(.*SpecIT$)</parameter>
-        <parameter name="ignoreTokenTypes">PatDefOrDcl,TypeDefOrDcl,FunDefOrDcl,TmplDef</parameter>
-        <parameter name="ignoreOverride">false</parameter>
-        <parameter name="indentStyle">anydoc</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="disallow.space.after.token">
- <justification>
- Correct formatting can help readability.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" enabled="true">
-      <parameters>
-        <parameter name="tokens">LPAREN</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="disallow.space.before.token">
- <justification>
- Correct formatting can help readability.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
-      <parameters>
-        <parameter name="tokens">COLON, COMMA, RPAREN</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="ensure.single.space.after.token">
- <justification>
- Correct formatting can help readability.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" enabled="true">
-      <parameters>
-        <parameter name="tokens">COLON, IF</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="ensure.single.space.before.token">
- <justification>
- Correct formatting can help readability.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" enabled="true">
-      <parameters>
-        <parameter name="tokens">LPAREN</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="import.ordering">
- <justification>
-  Consistent import ordering improves code readability and reduces unrelated changes in patches.
- </justification>
- <example-configuration>
- <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="true">
-      <parameters>
-        <parameter name="groups">java,scala,others</parameter>
-        <parameter name="group.java">javax?\..+</parameter>
-        <parameter name="group.scala">scala\..+</parameter>
-        <parameter name="group.others">.+</parameter>
-      </parameters>
-    </check>
- ]]>
- </example-configuration>
- </check>
-
- <check id="pattern.match.align">
-  <justification>
-    Correct formatting can help readability.
-  </justification>
-  <example-configuration>
-  <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.PatternMatchAlignChecker" enabled="true"/>
-  ]]>
-  </example-configuration>
- </check>
-
- <check id="empty.interpolated.strings">
-  <justification>
-   Empty interpolated strings are harder to read and not necessary.
-  </justification>
-  <example-configuration>
-   <![CDATA[
-    <check class="org.scalastyle.scalariform.EmptyInterpolatedStringChecker" level="warning" enabled="true"/>
-   ]]>
-  </example-configuration>
- </check>
-
- <check id="named.argument">
-  <justification>
-   Nameless literals make code harder to understand (consider `updateEntity(1, true)` and `updateEntity(id = 1, enabled = true)`).
-  </justification>
-  <example-configuration>
-   <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.NamedArgumentChecker" enabled="true">
-      <parameters>
-        <parameter name="checkString">false</parameter>
-        <parameter name="ignoreMethod">^set.+$</parameter>
-      </parameters>
-    </check>
-   ]]>
-  </example-configuration>
- </check>
-
- <check id="while.brace">
-  <justification>
-   While cannot be used in a pure-functional manner, that's why it's recommended to never omit braces according to Scala Style Guide.
-  </justification>
-  <example-configuration>
-   <![CDATA[
-    <check level="warning" class="org.scalastyle.scalariform.WhileBraceChecker" enabled="true"/>
-   ]]>
-  </example-configuration>
- </check>
-
- <check id="disallow.case.brace">
-  <justification>
-   Braces aren't required in case clauses. They should be omitted according to Scala Style Guide.
-  </justification>
-  <example-configuration>
-   <![CDATA[
-    <check class="org.scalastyle.scalariform.CaseBraceChecker" level="warning" enabled="true"/>
-   ]]>
-  </example-configuration>
- </check>
+        <check level="warning" class="org.scalastyle.scalariform.TodoCommentChecker" enabled="true">
+          <parameters>
+            <parameter name="words" type="string" default="TODO|FIXME" />
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="line.contains.tab">
+    <justification>Some say that tabs are evil.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="class.name">
+    <justification>The Scala style guide recommends that class names conform to certain standards.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[A-Z][A-Za-z]*$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="object.name">
+    <justification>The Scala style guide recommends that object names conform to certain standards.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[A-Z][A-Za-z]*$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="package.name">
+    <justification>The Scala style guide recommends that package names conform to certain standards.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.PackageNamesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[a-z]+$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="package.object.name">
+    <justification>The Scala style guide recommends that package object names conform to certain standards.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+          <parameters>
+            <parameter name="regex">^[a-z][A-Za-z]*$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="null">
+    <justification>Scala discourages use of `null`, preferring `Option`.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true">
+          <parameters>
+            <parameter name="allowNullChecks">true</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="return">
+    <justification>Use of `return` is not usually necessary in Scala. In fact, use of return can discourage a functional style of programming.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="equals.hash.code">
+    <justification>Defining either equals or hashCode in a class without defining the is a known source of bugs. Usually, when you define one, you should also define the other.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="structural.type">
+    <justification>Structural types in Scala can use reflection - this can have unexpected performance consequences. Warning: This check can also wrongly pick up type lamdbas and other such constructs. This checker should be used with care. You always have the alternative of the scalac checking for structural types.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="no.clone">
+    <justification>The clone method is difficult to get right. You can use the copy constructor of case classes rather than implementing clone. For more information on `clone()`, see Effective Java by Joshua Bloch pages.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="no.finalize">
+    <justification>`finalize()` is called when the object is garbage collected, and garbage collection is not guaranteed to happen. It is therefore unwise to rely on code in `finalize()` method.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="indentation">
+    <justification>Code that is not indented consistently can be hard to read.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.IndentationChecker" enabled="true">
+          <parameters>
+            <parameter name="tabSize">2</parameter>
+            <parameter name="methodParamIndentSize">2</parameter>
+            <parameter name="classParamIndentSize">4</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="whitespace.end.of.line">
+    <justification>Whitespace at the end of a line can cause problems when diffing between files or between versions.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true">
+          <parameters>
+            <parameter name="ignoreWhitespaceLines" type="boolean" default="false" />
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="illegal.imports">
+    <justification>Use of some classes can be discouraged for a project. For instance, use of `sun._` is generally discouraged because they are internal to the JDK and can be changed.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="parameter.number">
+    <justification>A method which has more than a certain number of parameters can be hard to understand.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+          <parameters>
+            <parameter name="maxParameters">8</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="simplify.boolean.expression">
+    <justification>A boolean expression which can be simplified can make code easier to read.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="spaces.before.plus">
+    <justification>An expression with spaces around `+` can be easier to read.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="spaces.after.plus">
+    <justification>An expression with spaces around `+` can be easier to read.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="no.whitespace.before.left.bracket">
+    <justification>If there is whitespace before a left bracket, this can be confusing to the reader.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="no.whitespace.after.left.bracket">
+    <justification>If there is whitespace after a left bracket, this can be confusing to the reader.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="no.whitespace.before.right.bracket">
+    <justification>If there is whitespace before a right bracket, this can be confusing to the reader.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeRightBracketChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="covariant.equals">
+    <justification>Mistakenly defining a covariant `equals()` method without overriding method `equals(java.lang.Object)` can produce unexpected runtime behaviour.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true" />
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="scaladoc">
+    <justification>Scaladoc is generally considered a good thing. Within reason.</justification>
+    <extra-description>Ignore tokens is a comma separated string that may include the following: `PatDefOrDcl` (variables), `TmplDef` (classes, traits), `TypeDefOrDcl` (type definitions), `FunDefOrDcl` (functions). Supported indentation styles are "scaladoc" (for ScalaDoc-style comments, with two spaces before the asterisk), "javadoc" (for JavaDoc-style comments, with a single space before the asterisk) or "anydoc" to support any style (any number of spaces before the asterisk). For backwards compatibility, if left empty, "anydoc" will be assumed.</extra-description>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true">
+          <parameters>
+            <parameter name="ignoreRegex">(.*Spec$)|(.*SpecIT$)</parameter>
+            <parameter name="ignoreTokenTypes">PatDefOrDcl,TypeDefOrDcl,FunDefOrDcl,TmplDef</parameter>
+            <parameter name="ignoreOverride">false</parameter>
+            <parameter name="indentStyle">anydoc</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="disallow.space.after.token">
+    <justification>Correct formatting can help readability.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" enabled="true">
+          <parameters>
+            <parameter name="tokens">LPAREN</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="disallow.space.before.token">
+    <justification>Correct formatting can help readability.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
+          <parameters>
+            <parameter name="tokens">COLON, COMMA, RPAREN</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="ensure.single.space.after.token">
+    <justification>Correct formatting can help readability.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" enabled="true">
+          <parameters>
+            <parameter name="tokens">COLON, IF</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="ensure.single.space.before.token">
+    <justification>Correct formatting can help readability.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.EnsureSingleSpaceBeforeTokenChecker" enabled="true">
+          <parameters>
+            <parameter name="tokens">LPAREN</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="import.ordering">
+    <justification>Consistent import ordering improves code readability and reduces unrelated changes in patches.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="true">
+          <parameters>
+            <parameter name="groups">java,scala,others</parameter>
+            <parameter name="group.java">javax?\..+</parameter>
+            <parameter name="group.scala">scala\..+</parameter>
+            <parameter name="group.others">.+</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="pattern.match.align">
+    <justification>Correct formatting can help readability.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.PatternMatchAlignChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check> id="empty.interpolated.strings">
+    <justification>Empty interpolated strings are harder to read and not necessary.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check class="org.scalastyle.scalariform.EmptyInterpolatedStringChecker" level="warning" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="named.argument">
+    <justification>Nameless literals make code harder to understand (consider `updateEntity(1, true)` and `updateEntity(id = 1, enabled = true)`).</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.NamedArgumentChecker" enabled="true">
+          <parameters>
+            <parameter name="checkString">false</parameter>
+            <parameter name="ignoreMethod">^set.+$</parameter>
+          </parameters>
+        </check>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="while.brace">
+    <justification>While cannot be used in a pure-functional manner, that's why it's recommended to never omit braces according to Scala Style Guide.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.WhileBraceChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
+  <check id="disallow.case.brace">
+    <justification>Braces aren't required in case clauses. They should be omitted according to Scala Style Guide.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check class="org.scalastyle.scalariform.CaseBraceChecker" level="warning" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
 </scalastyle-documentation>

--- a/src/main/scala/org/scalastyle/Checker.scala
+++ b/src/main/scala/org/scalastyle/Checker.scala
@@ -115,7 +115,8 @@ object Checker {
 class CheckerUtils(classLoader: Option[ClassLoader] = None) {
   private def comments(tokens: List[Token]): List[Comment] =
     tokens.flatMap { t =>
-      if (t.associatedWhitespaceAndComments == null) Nil else t.associatedWhitespaceAndComments.comments // scalastyle:ignore null
+      if (t.associatedWhitespaceAndComments == null) Nil
+      else t.associatedWhitespaceAndComments.comments // scalastyle:ignore null
     }
 
   def parseScalariform(source: String): ScalariformAst = {

--- a/src/main/scala/org/scalastyle/Output.scala
+++ b/src/main/scala/org/scalastyle/Output.scala
@@ -46,9 +46,7 @@ trait Output[T <: FileSpec] {
   def output(messages: java.util.List[Message[T]]): OutputResult = privateOutput(messages.asScala)
 
   private[this] def privateOutput(messages: Iterable[Message[T]]): OutputResult = {
-    messages.foreach { m =>
-      eachMessage(m); message(m)
-    }
+    messages.foreach { m => eachMessage(m); message(m) }
     OutputResult(files, errors, warnings, infos)
   }
 
@@ -132,9 +130,7 @@ object XmlOutput {
     val decl = """<?xml version="1.0" encoding="""" + encoding + """"?>"""
     val s = new XmlPrettyPrinter(width, step).format(toCheckstyleFormat(messageHelper, messages))
     // scalastyle:off regex
-    printToFile(target, encoding) { pw =>
-      pw.println(decl); pw.println(s)
-    }
+    printToFile(target, encoding) { pw => pw.println(decl); pw.println(s) }
     // scalastyle:on regex
   }
 

--- a/src/main/scala/org/scalastyle/ScalastyleConfiguration.scala
+++ b/src/main/scala/org/scalastyle/ScalastyleConfiguration.scala
@@ -208,24 +208,16 @@ object ScalastyleDefinition {
   }
 
   def stringAttr(node: Node, id: String): String =
-    attr(node, id, "", { s =>
-      s
-    })
+    attr(node, id, "", s => s)
 
   def levelAttr(node: Node, id: String): Level =
-    attr(node, id, Level.Warning, { s =>
-      Level(s)
-    })
+    attr(node, id, Level.Warning, s => Level(s))
 
   def typeAttr(node: Node, id: String): ParameterType =
-    attr(node, id, "string", { s =>
-      ParameterType(s)
-    })
+    attr(node, id, "string", s => ParameterType(s))
 
   def booleanAttr(node: Node, id: String): Boolean =
-    attr(node, id, "false", { s =>
-      "true" == s.toLowerCase()
-    })
+    attr(node, id, "false", s => "true" == s.toLowerCase())
 
   def attr[T](node: Node, id: String, defaultValue: String, fn: (String) => T): T = {
     node.attribute(id) match {

--- a/src/main/scala/org/scalastyle/scalariform/ImportsChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/ImportsChecker.scala
@@ -347,9 +347,7 @@ class ImportOrderChecker extends ScalariformChecker {
   private def countNewLines(start: Int, end: Int): Int = {
     var count = 0
     ast.tokens
-      .filter { t =>
-        t.offset >= start && t.offset < end
-      }
+      .filter(t => t.offset >= start && t.offset < end)
       .foreach { t =>
         val commentsToken = t.associatedWhitespaceAndComments
         if (commentsToken != null) { // scalastyle:ignore null

--- a/src/main/scala/org/scalastyle/util/CreateRulesMarkdown.scala
+++ b/src/main/scala/org/scalastyle/util/CreateRulesMarkdown.scala
@@ -30,7 +30,6 @@ import com.typesafe.config.ConfigFactory
 import org.scalastyle.BuildInfo
 import org.scalastyle.DefinitionChecker
 import org.scalastyle.ScalastyleDefinition
-import org.scalastyle.XmlPrettyPrinter
 
 // scalastyle:off magic.number
 

--- a/src/main/scala/org/scalastyle/util/CreateRulesMarkdown.scala
+++ b/src/main/scala/org/scalastyle/util/CreateRulesMarkdown.scala
@@ -86,7 +86,7 @@ object CreateRulesMarkdown {
     val desc = config.getString(c.id + ".description").replaceAll("''\\[''", "'\\\\['")
 
     val header = List(
-      s"""<a name="${id(c.className)}" />""",
+      s"""<a name="${id(c.className)}"></a>""",
       "",
       s"""### ${c.className} - ${desc}""",
       "",
@@ -116,16 +116,11 @@ object CreateRulesMarkdown {
       List(x.toString)
     }
 
-    val s = doc.example.map { x =>
-      new PrettyPrinter(1000, 1).format(toXml(docFile + ":" + c.id, x))
-    }
-    val x = s.map(t => <pre>{t}</pre>).map(x => new XmlPrettyPrinter(1000, 1).format(x))
+    val x = doc.example.map(x => new PrettyPrinter(1000, 1).format(toXml(docFile + ":" + c.id, x)))
 
-    val x2 = if (x.isEmpty) {
-      "TBD"
-    } else {
-      x.mkString("\nor\n")
-    }
+    val x2 =
+      if (x.isEmpty) "TBD"
+      else x.map(x => s"```xml\n$x\n```").mkString("\nor\n")
 
     val example = List("", "### Example configuration", x2)
 

--- a/src/test/scala/org/scalastyle/file/HeaderMatchesCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/file/HeaderMatchesCheckerTest.scala
@@ -94,14 +94,12 @@ class HeaderMatchesCheckerTest extends AssertionsForJUnit with CheckerTest {
   }
 
   val licenceRegexUnix = {
-    (licenseUnix flatMap { c =>
-      if (literalOK(c)) c.toString else "\\" + c
-    }).replace("2009-2010", "(?:\\d{4}-)?\\d{4}")
+    (licenseUnix flatMap { c => if (literalOK(c)) c.toString else "\\" + c })
+      .replace("2009-2010", "(?:\\d{4}-)?\\d{4}")
   }
   val licenceRegexWin = {
-    (licenseWin flatMap { c =>
-      if (literalOK(c)) c.toString else "\\" + c
-    }).replace("2009-2010", "(?:\\d{4}-)?\\d{4}")
+    (licenseWin flatMap { c => if (literalOK(c)) c.toString else "\\" + c })
+      .replace("2009-2010", "(?:\\d{4}-)?\\d{4}")
   }
 
   @Test def testRegexOK(): Unit = {


### PR DESCRIPTION
This PR makes the xml formatting more consistent. As a result, the documentation looks better with the code being highlighted using Scala syntax. It will also make it easier for any downstream dependencies (like [sonar-scala](https://sonar-scala.com)) to process and work with the documentation content.

Here's what's changed:
- used 2 space indentation for xml
- wrapped inline code between backticks
- wrapped code blocks between triple backticks, and
- made minor tweaks to the rules markdown generator