### PR TITLE
Fix snapshot versioning.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
+      - run: git fetch --prune --unshallow
       - uses: olafurpg/setup-scala@v7
         with:
           java-version: adopt@1.8


### PR DESCRIPTION
Fetch all tags so that sbt-dynver can determine the correct version for publishing a snapshot.