### PR TITLE
Adding ThrowChecker to detect usage of throw

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -407,3 +407,7 @@ while.brace.description = "Checks that while body have braces."
 disallow.case.brace.message = "Omit braces in case clauses."
 disallow.case.brace.label = "Omit braces in case clauses"
 disallow.case.brace.description = "Checks that braces aren't used in case clauses."
+
+throw.message = "Avoid using throw statements."
+throw.label = "No throw statements."
+throw.description = "Checks that throw is not used."

--- a/src/main/resources/scalastyle_definition.xml
+++ b/src/main/resources/scalastyle_definition.xml
@@ -134,6 +134,7 @@
   <checker class="org.scalastyle.file.NewLineAtEofChecker" id="newline.at.eof" defaultLevel="warning"/>
   <checker class="org.scalastyle.file.NoNewLineAtEofChecker" id="no.newline.at.eof" defaultLevel="warning"/>
   <checker class="org.scalastyle.scalariform.WhileChecker" id="while" defaultLevel="warning"/>
+  <checker class="org.scalastyle.scalariform.ThrowChecker" id="throw" defaultLevel="warning"/>
   <checker class="org.scalastyle.scalariform.VarFieldChecker" id="var.field" defaultLevel="warning"/>
   <checker class="org.scalastyle.scalariform.VarLocalChecker" id="var.local" defaultLevel="warning"/>
   <checker class="org.scalastyle.scalariform.RedundantIfChecker" id="if.redundant" defaultLevel="warning"/>

--- a/src/main/resources/scalastyle_documentation.xml
+++ b/src/main/resources/scalastyle_documentation.xml
@@ -206,6 +206,14 @@ if (bool_expression) expression1 else expression2
       ]]>
     </example-configuration>
   </check>
+  <check id="throw">
+    <justification>`throw` statements should be replaced with type-safe error constructs like `Try` and `Either`, which communicate the possibility of error in the type signature.</justification>
+    <example-configuration>
+      <![CDATA[
+        <check level="warning" class="org.scalastyle.scalariform.ThrowChecker" enabled="true"/>
+      ]]>
+    </example-configuration>
+  </check>
   <check id="var.field">
     <justification>`var` (mutable fields) are deprecated if you're using a strict functional style.</justification>
     <example-configuration>

--- a/src/main/scala/org/scalastyle/scalariform/AbstractTokenChecker.scala
+++ b/src/main/scala/org/scalastyle/scalariform/AbstractTokenChecker.scala
@@ -22,6 +22,7 @@ import _root_.scalariform.lexer.Tokens.INTEGER_LITERAL
 import _root_.scalariform.lexer.Tokens.RETURN
 import _root_.scalariform.lexer.Tokens.VARID
 import _root_.scalariform.lexer.Tokens.WHILE
+import _root_.scalariform.lexer.Tokens.THROW
 import _root_.scalariform.parser.CompilationUnit
 import org.scalastyle.PositionError
 import org.scalastyle.ScalariformChecker
@@ -32,9 +33,7 @@ abstract class AbstractTokenChecker(val errorKey: String, tokenType: TokenType) 
     val it = for {
       t <- ast.tokens
       if t.tokenType == tokenType && matches(t)
-    } yield {
-      PositionError(t.offset)
-    }
+    } yield PositionError(t.offset)
 
     it
   }
@@ -48,6 +47,7 @@ class UppercaseLChecker extends AbstractTokenChecker("uppercase.l", INTEGER_LITE
 
 class WhileChecker extends AbstractTokenChecker("while", WHILE)
 class ReturnChecker extends AbstractTokenChecker("return", RETURN)
+class ThrowChecker extends AbstractTokenChecker("throw", THROW)
 
 class TokenChecker extends AbstractTokenChecker("token", VARID) {
   private val DefaultRegex = "^$"

--- a/src/test/scala/org/scalastyle/scalariform/ThrowCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ThrowCheckerTest.scala
@@ -1,0 +1,5 @@
+package org.scalastyle.scalariform
+
+class ThrowCheckerTest {
+
+}

--- a/src/test/scala/org/scalastyle/scalariform/ThrowCheckerTest.scala
+++ b/src/test/scala/org/scalastyle/scalariform/ThrowCheckerTest.scala
@@ -1,5 +1,71 @@
+// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.scalastyle.scalariform
 
-class ThrowCheckerTest {
+import org.junit.Test
+import org.scalastyle.file.CheckerTest
+import org.scalatestplus.junit.AssertionsForJUnit
 
+// scalastyle:off magic.number
+
+class ThrowCheckerTest extends AssertionsForJUnit with CheckerTest {
+
+  protected val classUnderTest = classOf[ThrowChecker]
+
+  protected val key = "throw"
+
+  @Test def testZeroErrors(): Unit = {
+    val source = """
+class C1 {
+  /* This method does not throw an exception */
+  def m1(n: Int) = n
+
+  // This method also doesn't throw an exception */
+  def m2(n: Int) = n
+
+  // Use this function to throw away an integer.
+  def throwAway(n: Int): Unit = ()
+}
+"""
+    assertErrors(List(), source)
+  }
+
+  @Test def testOneError(): Unit = {
+    val source = """
+class C1 {
+  def divide(a: Int, b: Int) = {
+    if (b == 0) throw new IllegalArgumentException("please learn how to divide");
+    a / b
+  }
+}
+"""
+    assertErrors(List(columnError(4, 16)), source)
+  }
+
+  @Test def testTwoErrors(): Unit = {
+    val source = """
+class C1 {
+  def impatientOptionUser[A, B](o1: Option[A], o2: Option[B]): (A, B) = {
+    val v1: A = o1.getOrElse(throw new Exception("I really wanted a value of type A"))
+    val v2: B = o2.getOrElse(throw new Exception("I really wanted a value of type B"))
+    (v1, v2)
+  }
+}
+"""
+    assertErrors(List(columnError(4, 29), columnError(5, 29)), source)
+  }
 }


### PR DESCRIPTION
Adding a ThrowChecker, similar to the WhileChecker and ReturnChecker.
The PR should include the necessary tests and xml definitions. 
`sbt test` passes locally.
Let me know if anything is missing.

For context, this is related to my issue over on the sbt-scalastyle repo: https://github.com/beautiful-scala/sbt-scalastyle/issues
Basically, it doesn't seem to be possible to reliably identify `throw` tokens with a regular expression.